### PR TITLE
Private.xml for full meta key functionality, including special sequences...

### DIFF
--- a/KeyRemap4MacBook/private.append_escape_for_keys/private.xml
+++ b/KeyRemap4MacBook/private.append_escape_for_keys/private.xml
@@ -1,39 +1,173 @@
 <?xml version="1.0"?>
 <root>
+  <appdef>
+    <appname>TERMINAL</appname>
+    <equal>com.apple.Terminal</equal>
+  </appdef>
   <item>
-    <name>PC Application Key to ModifierFlag::EXTRA1</name>
+    <name>PC Application Key to Meta Modifier Key in Terminal.app</name>
     <appendix>(EXTRA1+Key to Escape,Key)</appendix>
+    <only>TERMINAL</only>
     <identifier>private.append_escape_for_keys</identifier>
-    <!-- CapsLock (which is changed to pc application key by PCKeyboardHack) to ModifierFlag::EXTRA1 -->
+    <!-- Left Control (which is changed to pc application key by PCKeyboardHack) to ModifierFlag::EXTRA1 -->
     <autogen>--KeyToKey-- KeyCode::PC_APPLICATION, KeyCode::VK_MODIFIER_EXTRA1</autogen>
 
-    <autogen>--KeyToKey-- KeyCode::Q, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::Q</autogen>
-    <autogen>--KeyToKey-- KeyCode::W, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::W</autogen>
-    <autogen>--KeyToKey-- KeyCode::E, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::E</autogen>
-    <autogen>--KeyToKey-- KeyCode::R, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::R</autogen>
-    <autogen>--KeyToKey-- KeyCode::T, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::T</autogen>
-    <autogen>--KeyToKey-- KeyCode::Y, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::Y</autogen>
-    <autogen>--KeyToKey-- KeyCode::U, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::U</autogen>
-    <autogen>--KeyToKey-- KeyCode::I, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::I</autogen>
-    <autogen>--KeyToKey-- KeyCode::O, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::O</autogen>
-    <autogen>--KeyToKey-- KeyCode::P, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::P</autogen>
+    <autogen>--KeyToKey-- KeyCode::RETURN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::RETURN</autogen>
+    <autogen>--KeyToKey-- KeyCode::BACKSLASH, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::BACKSLASH</autogen>
+    <autogen>--KeyToKey-- KeyCode::TAB, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::TAB</autogen>
+    <autogen>--KeyToKey-- KeyCode::SPACE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SPACE</autogen>
+    <autogen>--KeyToKey-- KeyCode::BACKQUOTE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::BACKQUOTE</autogen>
+    <autogen>--KeyToKey-- KeyCode::DELETE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::DELETE</autogen>
+    <autogen>--KeyToKey-- KeyCode::ENTER_POWERBOOK, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::ENTER_POWERBOOK</autogen>
+    <autogen>--KeyToKey-- KeyCode::ESCAPE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::ESCAPE</autogen>
+    <autogen>--KeyToKey-- KeyCode::ENTER, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::ENTER</autogen>
+
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_DOT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_DOT</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_MULTIPLY, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_MULTIPLY</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_PLUS, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_PLUS</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_CLEAR, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_CLEAR</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_SLASH, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_SLASH</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_MINUS, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_MINUS</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_EQUAL, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_EQUAL</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_COMMA, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_COMMA</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_0, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_0</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_1, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_1</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_2, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_2</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_3, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_3</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_4, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_4</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_5, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_5</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_6, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_6</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_7, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_7</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_8, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_8</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEYPAD_9, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEYPAD_9</autogen>
 
     <autogen>--KeyToKey-- KeyCode::A, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::A</autogen>
     <autogen>--KeyToKey-- KeyCode::S, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::S</autogen>
     <autogen>--KeyToKey-- KeyCode::D, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::D</autogen>
     <autogen>--KeyToKey-- KeyCode::F, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F</autogen>
-    <autogen>--KeyToKey-- KeyCode::G, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::G</autogen>
     <autogen>--KeyToKey-- KeyCode::H, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::H</autogen>
-    <autogen>--KeyToKey-- KeyCode::J, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::J</autogen>
-    <autogen>--KeyToKey-- KeyCode::K, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::K</autogen>
-    <autogen>--KeyToKey-- KeyCode::L, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::L</autogen>
-
+    <autogen>--KeyToKey-- KeyCode::G, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::G</autogen>
     <autogen>--KeyToKey-- KeyCode::Z, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::Z</autogen>
     <autogen>--KeyToKey-- KeyCode::X, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::X</autogen>
     <autogen>--KeyToKey-- KeyCode::C, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::C</autogen>
     <autogen>--KeyToKey-- KeyCode::V, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::V</autogen>
     <autogen>--KeyToKey-- KeyCode::B, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::B</autogen>
+    <autogen>--KeyToKey-- KeyCode::Q, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::Q</autogen>
+    <autogen>--KeyToKey-- KeyCode::W, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::W</autogen>
+    <autogen>--KeyToKey-- KeyCode::E, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::E</autogen>
+    <autogen>--KeyToKey-- KeyCode::R, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::R</autogen>
+    <autogen>--KeyToKey-- KeyCode::Y, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::Y</autogen>
+    <autogen>--KeyToKey-- KeyCode::T, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::T</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_1, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_1</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_2, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_2</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_3, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_3</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_4, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_4</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_6, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_6</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_5, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_5</autogen>
+    <autogen>--KeyToKey-- KeyCode::EQUAL, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::EQUAL</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_9, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_9</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_7, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_7</autogen>
+    <autogen>--KeyToKey-- KeyCode::MINUS, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::MINUS</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_8, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_8</autogen>
+    <autogen>--KeyToKey-- KeyCode::KEY_0, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::KEY_0</autogen>
+    <autogen>--KeyToKey-- KeyCode::O, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::O</autogen>
+    <autogen>--KeyToKey-- KeyCode::U, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::U</autogen>
+    <autogen>--KeyToKey-- KeyCode::I, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::I</autogen>
+    <autogen>--KeyToKey-- KeyCode::P, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::P</autogen>
+    <autogen>--KeyToKey-- KeyCode::L, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::L</autogen>
+    <autogen>--KeyToKey-- KeyCode::J, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::J</autogen>
+    <autogen>--KeyToKey-- KeyCode::K, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::K</autogen>
+    <autogen>--KeyToKey-- KeyCode::SLASH, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SLASH</autogen>
     <autogen>--KeyToKey-- KeyCode::N, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::N</autogen>
     <autogen>--KeyToKey-- KeyCode::M, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::M</autogen>
+    <autogen>--KeyToKey-- KeyCode::DOT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::DOT</autogen>
+
+    <autogen>--KeyToKey-- KeyCode::SEMICOLON, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SEMICOLON</autogen>
+    <autogen>--KeyToKey-- KeyCode::COMMA, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::COMMA</autogen>
+    <autogen>--KeyToKey-- KeyCode::BRACKET_LEFT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::BRACKET_LEFT</autogen>
+    <autogen>--KeyToKey-- KeyCode::BRACKET_RIGHT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::BRACKET_RIGHT</autogen>
+    <autogen>--KeyToKey-- KeyCode::QUOTE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::QUOTE</autogen>
+
+    <autogen>--KeyToKey-- KeyCode::F1, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F1</autogen>
+    <autogen>--KeyToKey-- KeyCode::F2, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F2</autogen>
+    <autogen>--KeyToKey-- KeyCode::F3, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F3</autogen>
+    <autogen>--KeyToKey-- KeyCode::F4, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F4</autogen>
+    <autogen>--KeyToKey-- KeyCode::F5, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F5</autogen>
+    <autogen>--KeyToKey-- KeyCode::F6, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F6</autogen>
+    <autogen>--KeyToKey-- KeyCode::F7, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F7</autogen>
+    <autogen>--KeyToKey-- KeyCode::F8, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F8</autogen>
+    <autogen>--KeyToKey-- KeyCode::F9, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F9</autogen>
+    <autogen>--KeyToKey-- KeyCode::F10, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F10</autogen>
+    <autogen>--KeyToKey-- KeyCode::F11, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F11</autogen>
+    <autogen>--KeyToKey-- KeyCode::F12, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F12</autogen>
+    <autogen>--KeyToKey-- KeyCode::F13, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F13</autogen>
+    <autogen>--KeyToKey-- KeyCode::F14, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F14</autogen>
+    <autogen>--KeyToKey-- KeyCode::F15, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F15</autogen>
+    <autogen>--KeyToKey-- KeyCode::F16, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F16</autogen>
+    <autogen>--KeyToKey-- KeyCode::F17, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F17</autogen>
+    <autogen>--KeyToKey-- KeyCode::F18, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F18</autogen>
+    <autogen>--KeyToKey-- KeyCode::F19, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::F19</autogen>
+<!-- 
+    <autogen>--KeyToKey-- KeyCode::PC_KEYPAD_NUMLOCK, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_KEYPAD_NUMLOCK</autogen>
+    <autogen>--KeyToKey-- KeyCode::PC_APPLICATION, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_APPLICATION</autogen>
+    <autogen>--KeyToKey-- KeyCode::PC_PRINTSCREEN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_PRINTSCREEN</autogen>
+    <autogen>--KeyToKey-- KeyCode::PC_SCROLLLOCK, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_SCROLLLOCK</autogen>
+    <autogen>--KeyToKey-- KeyCode::PC_PAUSE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_PAUSE</autogen>
+    <autogen>--KeyToKey-- KeyCode::PC_POWER, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_POWER</autogen>
+    <autogen>--KeyToKey-- KeyCode::HELP, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::HELP</autogen>
+ -->
+
+    <autogen>--KeyToKey-- KeyCode::PC_INSERT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_INSERT</autogen>
+    <autogen>--KeyToKey-- KeyCode::PC_BS, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_BS</autogen>
+    <autogen>--KeyToKey-- KeyCode::PC_DEL, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PC_DEL</autogen>
+
+    <autogen>--KeyToKey-- KeyCode::FORWARD_DELETE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::FORWARD_DELETE</autogen>
+
+    <autogen>--KeyToKey-- KeyCode::CURSOR_LEFT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::CURSOR_LEFT</autogen>
+    <autogen>--KeyToKey-- KeyCode::CURSOR_RIGHT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::CURSOR_RIGHT</autogen>
+    <autogen>--KeyToKey-- KeyCode::CURSOR_DOWN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::CURSOR_DOWN</autogen>
+    <autogen>--KeyToKey-- KeyCode::CURSOR_UP, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::CURSOR_UP</autogen>
+
+    <autogen>--KeyToKey-- KeyCode::PAGEUP, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PAGEUP</autogen>
+    <autogen>--KeyToKey-- KeyCode::PAGEDOWN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::PAGEDOWN</autogen>
+    <autogen>--KeyToKey-- KeyCode::END, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::END</autogen>
+    <autogen>--KeyToKey-- KeyCode::HOME, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::HOME</autogen>
+
+<!--
+    <autogen>--KeyToKey-- KeyCode::JIS_YEN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_YEN</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_UNDERSCORE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_UNDERSCORE</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_EISUU, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_EISUU</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_KANA, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_KANA</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_BRACKET_LEFT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_BRACKET_LEFT</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_BRACKET_RIGHT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_BRACKET_RIGHT</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_ATMARK, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_ATMARK</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_COLON, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_COLON</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_HAT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_HAT</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_DAKUON, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_DAKUON</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_HANDAKUON, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_HANDAKUON</autogen>
+    <autogen>--KeyToKey-- KeyCode::JIS_PC_HAN_ZEN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::JIS_PC_HAN_ZEN</autogen>
+-->
+
+    <autogen>--KeyToKey-- KeyCode::RUSSIAN_PARAGRAPH, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::RUSSIAN_PARAGRAPH</autogen>
+    <autogen>--KeyToKey-- KeyCode::RUSSIAN_TILDE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::RUSSIAN_TILDE</autogen>
+    <autogen>--KeyToKey-- KeyCode::UK_SECTION, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::UK_SECTION</autogen>
+    <autogen>--KeyToKey-- KeyCode::GERMAN_QUOTE, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::GERMAN_QUOTE</autogen>
+    <autogen>--KeyToKey-- KeyCode::GERMAN_CIRCUMFLEX, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::GERMAN_CIRCUMFLEX</autogen>
+    <autogen>--KeyToKey-- KeyCode::GERMAN_LESS_THAN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::GERMAN_LESS_THAN</autogen>
+    <autogen>--KeyToKey-- KeyCode::GERMAN_PC_LESS_THAN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::GERMAN_PC_LESS_THAN</autogen>
+    <autogen>--KeyToKey-- KeyCode::FRENCH_MINUS, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::FRENCH_MINUS</autogen>
+    <autogen>--KeyToKey-- KeyCode::FRENCH_RIGHT_PAREN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::FRENCH_RIGHT_PAREN</autogen>
+    <autogen>--KeyToKey-- KeyCode::FRENCH_EQUAL, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::FRENCH_EQUAL</autogen>
+    <autogen>--KeyToKey-- KeyCode::FRENCH_HAT, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::FRENCH_HAT</autogen>
+    <autogen>--KeyToKey-- KeyCode::FRENCH_DOLLAR, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::FRENCH_DOLLAR</autogen>
+    <autogen>--KeyToKey-- KeyCode::SWEDISH_SECTION, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SWEDISH_SECTION</autogen>
+    <autogen>--KeyToKey-- KeyCode::SWEDISH_LESS_THAN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SWEDISH_LESS_THAN</autogen>
+    <autogen>--KeyToKey-- KeyCode::SWISS_SECTION, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SWISS_SECTION</autogen>
+    <autogen>--KeyToKey-- KeyCode::SWISS_LESS_THAN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SWISS_LESS_THAN</autogen>
+    <autogen>--KeyToKey-- KeyCode::SPANISH_ORDINAL_INDICATOR, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SPANISH_ORDINAL_INDICATOR</autogen>
+    <autogen>--KeyToKey-- KeyCode::SPANISH_LESS_THAN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::SPANISH_LESS_THAN</autogen>
+    <autogen>--KeyToKey-- KeyCode::ITALIAN_BACKSLASH, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::ITALIAN_BACKSLASH</autogen>
+    <autogen>--KeyToKey-- KeyCode::ITALIAN_LESS_THAN, ModifierFlag::EXTRA1, KeyCode::ESCAPE, KeyCode::ITALIAN_LESS_THAN</autogen>
+
   </item>
 </root>


### PR DESCRIPTION
... from keys like the cursor keys. Also includes several nonstandard keys, because they may be remapped to certain characters in the keyboard layouts. Terminal apps can bind any character to the meta; that's why it's important to include everything.
